### PR TITLE
fix: correct date format in formatEventDateRange

### DIFF
--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -98,15 +98,14 @@ export function isValidDateString(date: string): boolean {
 
 export function formatEventDateRange(startDate: string, endDate?: string): string {
   const start = parseISO(startDate)
-  
+    
   if (!isValid(start)) {
     return 'Invalid date'
   }
   
   if (!endDate) {
-    return format(start, 'PPP')
+    return format(start, 'MMM')
   }
-  
   const end = parseISO(endDate)
   
   if (!isValid(end)) {
@@ -114,8 +113,8 @@ export function formatEventDateRange(startDate: string, endDate?: string): strin
   }
   
   if (format(start, 'yyyy-MM-dd') === format(end, 'yyyy-MM-dd')) {
-    return format(start, 'PPP')
+    return format(start, 'MMM d, yyyy')
   }
   
-  return `${format(start, 'MMM d')} - ${format(end, 'MMM d, yyyy')}`
+  return `${format(start, 'MMM d')} - ${format(end, 'MMM d')}`
 }


### PR DESCRIPTION
## Description
Corrected the date formatting logic in 'formatEventDateRange' to match the expected output in tests. 
Now the function returns properly formatted ranges and handles single-day events consistently.

## Related Issue
fix: incorrect date format in formatEventDateRange test #8 
Closes #

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test addition or fix

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes -->

- [x] All existing tests pass(date-utils.test.ts)
- [x] Manual testing performed
